### PR TITLE
fix doc scope generation

### DIFF
--- a/templates/detail_record.dust
+++ b/templates/detail_record.dust
@@ -16,7 +16,7 @@
                 <td class="type">{>inline_type:type/}</td>
                 <td class="field">{name}{?order} <span class="label">{order}</span>{/order}</td>
                 <td class="field-doc">{default_str}</td>
-                <td class="field-doc">{doc|md|s}</td>
+                <td class="field-doc">{.doc|md|s}</td>
             </tr>
         {/fields}
         </tbody>


### PR DESCRIPTION
See original bug description in https://github.com/ckatzorke/avrodoc-plus/pull/3 (Credits go to @Khrol)

I have confirmed that this is also the case with this fork, and that this patch solves the issue.

BTW, there is no issue tracking in this repo, is that something you could turn on?