### PR TITLE
fix: search box width to wide

### DIFF
--- a/public/stylesheets/style.less
+++ b/public/stylesheets/style.less
@@ -180,6 +180,5 @@
 #search-schemas {
   padding: 5px;
   margin-top: 5px;
-  width: 350px;
   border-radius: 4px;
 }


### PR DESCRIPTION
The search box is wider than the menu to the right, this seems like a bug, and not something everyone should fix with their own stylesheet!?

![image](https://user-images.githubusercontent.com/2505178/114976456-4c6dc280-9e86-11eb-8d85-72dffa220dbb.png)

Inspect:
![image](https://user-images.githubusercontent.com/2505178/114976493-5b547500-9e86-11eb-9b5d-8f16667332fd.png)

With this fix:
![image](https://user-images.githubusercontent.com/2505178/114976535-6a3b2780-9e86-11eb-9258-21dc0e79a846.png)
